### PR TITLE
Add support for subdirectories for scanned files

### DIFF
--- a/fileio.c
+++ b/fileio.c
@@ -501,6 +501,7 @@ int findfiles(char const *dir, void *data,
 	    if (r < 0)
     	    break;
     }
+    }
 
     closedir(dp);
     return TRUE;

--- a/fileio.c
+++ b/fileio.c
@@ -423,7 +423,7 @@ char *getpathforfileindir(char const *dir, char const *filename)
     int		m, n;
 
     m = strlen(filename);
-    if (!dir || !*dir || strchr(filename, DIRSEP_CHAR)) {
+    if (!dir || !*dir) {
 	if (m > PATH_MAX) {
 	    errno = ENAMETOOLONG;
 	    return NULL;
@@ -452,7 +452,7 @@ int openfileindir(fileinfo *file, char const *dir, char const *filename,
     char	buf[PATH_MAX + 1];
     int		m, n;
 
-    if (!dir || !*dir || strchr(filename, DIRSEP_CHAR))
+    if (!dir || !*dir)
 	return fileopen(file, filename, mode, msg);
 
     n = strlen(dir);

--- a/fileio.c
+++ b/fileio.c
@@ -488,7 +488,7 @@ int findfiles(char const *dir, void *data,
 
     while ((dent = readdir(dp))) {
 	if (dent->d_name[0] == '.')
-	    continue;
+        continue;
 
     filepath = getpathforfileindir(dir, dent->d_name);
 
@@ -497,11 +497,13 @@ int findfiles(char const *dir, void *data,
             return rres;
     }
     else {
-	    r = (*filecallback)(filepath, data);
-	    if (r < 0)
-    	    break;
+        r = (*filecallback)(filepath, data);
+        if (r < 0)
+            break;
     }
     }
+
+    free(filepath);
 
     closedir(dp);
     return TRUE;

--- a/series.c
+++ b/series.c
@@ -516,9 +516,7 @@ static int getseriesfile(char const *ogfilename, void *data)
     unsigned long	magic;
     char	       *datfilename;
     int			config, f;
-	char        *filename = malloc(strlen(ogfilename) - strlen(sdata->curdir));
-
-	strcpy(filename, ogfilename + strlen(sdata->curdir) + 1);
+		char         *filename = ogfilename + strlen(sdata->curdir) + 1;
 
     clearfileinfo(&file);
     if (!openfileindir(&file, sdata->curdir, filename, "rb", "unknown error"))
@@ -610,9 +608,7 @@ static int getmapfile(char const *ogfilename, void *data)
     unsigned long	magic;
     int			f;
 
-	char        *filename = malloc(strlen(ogfilename) - strlen(sdata->curdir));
-
-	strcpy(filename, ogfilename + strlen(sdata->curdir) + 1);
+		char        *filename = ogfilename + strlen(sdata->curdir) + 1;
 
     clearfileinfo(&file);
     if (!openfileindir(&file, sdata->curdir, filename, "rb", "unknown error"))
@@ -728,8 +724,8 @@ static gameseries* createnewseries
     char *newdacname = generatenewdacname(datfile, ruleset);
     int ok = createnewdacfile(newdacname, datfile, ruleset);
     if (!ok) {
-	//errmsg(newdacname, "Attempt to create %s ruleset .dac for %s failed",
-	  // ruleset == Ruleset_MS ? "MS" : "Lynx", datfile->filename);
+	errmsg(newdacname, "Attempt to create %s ruleset .dac for %s failed",
+	  ruleset == Ruleset_MS ? "MS" : "Lynx", datfile->filename);
     }
     if (errno == EEXIST) return NULL;
 

--- a/series.c
+++ b/series.c
@@ -358,8 +358,7 @@ int readseriesfile(gameseries *series)
     }
 
     if (!series->mapfile.fp) {
-	if (!openfileindir(&series->mapfile, seriesdir,
-			   series->mapfilename, "rb", "unknown error"))
+	if (!fileopen(&series->mapfile, series->mapfilename, "rb", "unknown error"))
 	    return FALSE;
 	if (!readseriesheader(series))
 	    return FALSE;
@@ -509,7 +508,7 @@ static char *readconfigfile(fileinfo *file, gameseries *series)
  * list stored under the second argument. This function is used as a
  * findfiles() callback.
  */
-static int getseriesfile(char const *filename, void *data)
+static int getseriesfile(char const *ogfilename, void *data)
 {
     fileinfo		file;
     seriesdata	       *sdata = (seriesdata*)data;
@@ -517,6 +516,9 @@ static int getseriesfile(char const *filename, void *data)
     unsigned long	magic;
     char	       *datfilename;
     int			config, f;
+	char        *filename = malloc(strlen(ogfilename) - strlen(sdata->curdir));
+
+	strcpy(filename, ogfilename + strlen(sdata->curdir) + 1);
 
     clearfileinfo(&file);
     if (!openfileindir(&file, sdata->curdir, filename, "rb", "unknown error"))
@@ -600,13 +602,17 @@ static int getseriesfile(char const *filename, void *data)
 /* Determine whether the file is a map file. If so, add it to the list of
  * available map files. This function is used as a findfiles() callback.
  */
-static int getmapfile(char const *filename, void *data)
+static int getmapfile(char const *ogfilename, void *data)
 {
     fileinfo		file;
     seriesdata	       *sdata = (seriesdata*)data;
     gameseries	        s;
     unsigned long	magic;
     int			f;
+
+	char        *filename = malloc(strlen(ogfilename) - strlen(sdata->curdir));
+
+	strcpy(filename, ogfilename + strlen(sdata->curdir) + 1);
 
     clearfileinfo(&file);
     if (!openfileindir(&file, sdata->curdir, filename, "rb", "unknown error"))
@@ -722,8 +728,8 @@ static gameseries* createnewseries
     char *newdacname = generatenewdacname(datfile, ruleset);
     int ok = createnewdacfile(newdacname, datfile, ruleset);
     if (!ok) {
-	errmsg(newdacname, "Attempt to create %s ruleset .dac for %s failed",
-	   ruleset == Ruleset_MS ? "MS" : "Lynx", datfile->filename);
+	//errmsg(newdacname, "Attempt to create %s ruleset .dac for %s failed",
+	  // ruleset == Ruleset_MS ? "MS" : "Lynx", datfile->filename);
     }
     if (errno == EEXIST) return NULL;
 

--- a/solution.c
+++ b/solution.c
@@ -757,21 +757,17 @@ typedef	struct solutiondata {
 } solutiondata;
 
 /* If the given file starts with the prefix stored in the solutiondata
- * structure, then add it to the pool of filenames, prefixed with
- * "1-". This function is a callback for findfiles().
+ * structure, then add it to the pool of filenames.
+ * This function is a callback for findfiles().
  */
 static int getsolutionfile(char const *filename, void *data)
 {
     solutiondata       *sdata = data;
     int			n;
 
-    filename = skippathname(filename);
-
-    if (!memcmp(filename, sdata->prefix, sdata->prefixlen)) {
+    if (!memcmp(skippathname(filename), sdata->prefix, sdata->prefixlen)) {
 	n = strlen(filename) + 1;
-	x_alloc(sdata->pool, sdata->allocated + n + 2);
-	sdata->pool[sdata->allocated++] = '1';
-	sdata->pool[sdata->allocated++] = '-';
+	x_alloc(sdata->pool, sdata->allocated + n);
 	memcpy(sdata->pool + sdata->allocated, filename, n);
 	sdata->allocated += n;
 	++sdata->count;
@@ -824,11 +820,16 @@ int createsolutionfilelist(gameseries const *series, int morethanone,
     table->items[0] = "2-Select a solution file";
     offset = 0;
     for (i = 0 ; i < s.count ; ++i) {
-	n = strlen(s.pool + offset) + 1;
-	filelist[i] = s.pool + offset + 2;
+	char *tname = s.pool + offset + strlen(savedir) + 1;
+	char *displayedname = malloc(strlen(tname) + 4);
+	displayedname[0] = '1';
+	displayedname[1] = '-';
+	displayedname[2] = 0;
+	strcat(displayedname, tname);
 	table->items[2 * i + 1] = "1+\267";
-	table->items[2 * i + 2] = s.pool + offset;
-	offset += n;
+	table->items[2 * i + 2] = displayedname;
+	filelist[i] = tname;
+	offset += strlen(s.pool + offset) + 1;
     }
 
     *pfilelist = filelist;

--- a/solution.c
+++ b/solution.c
@@ -765,6 +765,8 @@ static int getsolutionfile(char const *filename, void *data)
     solutiondata       *sdata = data;
     int			n;
 
+    filename = skippathname(filename);
+
     if (!memcmp(filename, sdata->prefix, sdata->prefixlen)) {
 	n = strlen(filename) + 1;
 	x_alloc(sdata->pool, sdata->allocated + n + 2);

--- a/tworld.c
+++ b/tworld.c
@@ -1547,9 +1547,6 @@ static void findlevelfromhistory(gamespec *gs, char const *name)
     }
 }
 
-#define OPEN_PAREN (
-#define CLOSED_PAREN )
-
 #define PRODUCE_SINGLE_COLUMN_TABLE(table, heading, data, count, L, R) do { \
     size_t _alloc = 0; \
     _alloc += 3 + strlen(heading); \

--- a/tworld.c
+++ b/tworld.c
@@ -1612,7 +1612,7 @@ static int chooseseries(seriesdata *series, int *pn, int founddefault)
 #else
     tablespec mftable;
     PRODUCE_SINGLE_COLUMN_TABLE(mftable, "Levelset",
-	series->mflist, series->mfcount, skippathname OPEN_PAREN, .filename CLOSED_PAREN);
+	series->mflist, series->mfcount, , .filename);
 
     /* Choose mapfile to be selected by default */
     int n = (founddefault ? findseries(series, *pn) : 0);

--- a/tworld.c
+++ b/tworld.c
@@ -1547,6 +1547,9 @@ static void findlevelfromhistory(gamespec *gs, char const *name)
     }
 }
 
+#define OPEN_PAREN (
+#define CLOSED_PAREN )
+
 #define PRODUCE_SINGLE_COLUMN_TABLE(table, heading, data, count, L, R) do { \
     size_t _alloc = 0; \
     _alloc += 3 + strlen(heading); \
@@ -1609,7 +1612,7 @@ static int chooseseries(seriesdata *series, int *pn, int founddefault)
 #else
     tablespec mftable;
     PRODUCE_SINGLE_COLUMN_TABLE(mftable, "Levelset",
-	series->mflist, series->mfcount, , .filename);
+	series->mflist, series->mfcount, skippathname OPEN_PAREN, .filename CLOSED_PAREN);
 
     /* Choose mapfile to be selected by default */
     int n = (founddefault ? findseries(series, *pn) : 0);


### PR DESCRIPTION
Hello!
This is a small QOL feature I wanted to add to TW for a long time, as having read-only places to put sets into was really annoying and the no-symlink nature of the TW map scan was getting to me, this just scans for subdirectories when searching for solutions, maps and series files, nothing more.
My C is not perfect, so let me know if I should change anything.
(By the way, don't let my repo fork name fool you, this branch is Wii-free!)